### PR TITLE
가맹점의 주문요청 방식 변경

### DIFF
--- a/src/main/java/com/varc/brewnetapp/domain/member/query/service/MemberService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/member/query/service/MemberService.java
@@ -15,4 +15,5 @@ public interface MemberService {
     Page<OrderPrintDTO> findSealHistory(Pageable page, String startDate, String endDate);
 
     FranchiseDTO getFranchiseInfoByLoginId(String loginId);
+    MemberDTO getMemberByLoginId(String loginId);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/member/query/service/MemberServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/member/query/service/MemberServiceImpl.java
@@ -108,6 +108,8 @@ public class MemberServiceImpl implements MemberService {
 
     }
 
+    @Override
+    @Transactional
     public FranchiseDTO getFranchiseInfoByLoginId(String loginId) {
         FranchiseDTO franchiseDTO = memberMapper.getFranchiseInfoBy(loginId);
         if (franchiseDTO == null) {
@@ -115,5 +117,11 @@ public class MemberServiceImpl implements MemberService {
         } else {
             return franchiseDTO;
         }
+    }
+
+    @Override
+    @Transactional
+    public MemberDTO getMemberByLoginId(String loginId) {
+        return memberMapper.selectMember(loginId);
     }
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQOrderController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQOrderController.java
@@ -1,6 +1,7 @@
 package com.varc.brewnetapp.domain.order.command.application.controller;
 
 import com.varc.brewnetapp.common.ResponseMessage;
+import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.service.OrderService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,13 +19,14 @@ public class HQOrderController {
         this.orderService = orderService;
     }
 
-    @PostMapping("/request/{orderCode}/reject")
+    @PostMapping("/reject/{orderCode}/reject")
     public ResponseEntity<ResponseMessage<Object>> drafterReject(
             @PathVariable("orderCode") Integer orderCode,
-            @RequestAttribute("loginId") String loginId
+            @RequestAttribute("loginId") String loginId,
+            @RequestBody DrafterRejectOrderRequestDTO rejectOrderRequestDTO
     ) {
 
-        orderService.rejectOrderByDrafter(orderCode, loginId);
+        orderService.rejectOrderByDrafter(orderCode, rejectOrderRequestDTO, loginId);
 
         return ResponseEntity.ok(
                 new ResponseMessage<>(200, "order request successfully rejected", null)

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQOrderController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQOrderController.java
@@ -1,8 +1,11 @@
 package com.varc.brewnetapp.domain.order.command.application.controller;
 
 import com.varc.brewnetapp.common.ResponseMessage;
+import com.varc.brewnetapp.domain.member.query.service.MemberService;
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +16,27 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/v1/hq/orders")
 public class HQOrderController {
     private final OrderService orderService;
+    private final MemberService memberService;
 
     @Autowired
-    public HQOrderController(OrderService orderService) {
+    public HQOrderController(OrderService orderService, MemberService memberService) {
         this.orderService = orderService;
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/request/{orderCode}")
+    @Operation(summary = "가맹점 주문 요청건에 대한 일반 관리자의 상신")
+    public ResponseEntity<ResponseMessage<Object>> requestApproveOrder(
+            @PathVariable Integer orderCode,
+            @RequestAttribute("loginId") String loginId,
+            @RequestBody OrderApproveRequestDTO orderApproveRequestDTO
+    ) {
+        int memberCode = memberService.getMemberByLoginId(loginId).getMemberCode();
+
+        boolean done = orderService.requestApproveOrder(orderCode, memberCode, orderApproveRequestDTO);
+        return ResponseEntity.ok(
+                new ResponseMessage<>(200, "order approval requested successfully", null)
+        );
     }
 
     @PostMapping("/reject/{orderCode}/reject")

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQOrderController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQOrderController.java
@@ -18,10 +18,13 @@ public class HQOrderController {
         this.orderService = orderService;
     }
 
-    @PostMapping("/reject/request/{orderCode}")
-    public ResponseEntity<ResponseMessage<Object>> drafterReject(@PathVariable("orderCode") String orderCode) {
+    @PostMapping("/request/{orderCode}/reject")
+    public ResponseEntity<ResponseMessage<Object>> drafterReject(
+            @PathVariable("orderCode") Integer orderCode,
+            @RequestAttribute("loginId") String loginId
+    ) {
 
-//        orderService.rejectOrderByDrafter(orderCode);
+        orderService.rejectOrderByDrafter(orderCode, loginId);
 
         return ResponseEntity.ok(
                 new ResponseMessage<>(200, "order request successfully rejected", null)

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQSuperController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQSuperController.java
@@ -1,7 +1,10 @@
 package com.varc.brewnetapp.domain.order.command.application.controller;
 
 import com.varc.brewnetapp.common.ResponseMessage;
+import com.varc.brewnetapp.domain.member.query.service.MemberService;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestApproveDTO;
 import com.varc.brewnetapp.domain.order.command.application.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -12,18 +15,25 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/v1/super/orders")
 public class HQSuperController {
     private final OrderService orderService;
+    private final MemberService memberservice;
 
     @Autowired
-    public HQSuperController(OrderService orderService) {
+    public HQSuperController(OrderService orderService,
+                             MemberService memberservice) {
         this.orderService = orderService;
+        this.memberservice = memberservice;
     }
 
     @PostMapping("/approve/{orderCode}")
+    @Operation(summary = "책임 관리자가 상신된 주문 요청에 대한 승인")
     public ResponseEntity<ResponseMessage<Object>> approveOrderRequest(
             @PathVariable String orderCode,
-            @RequestAttribute String loginId
+            @RequestAttribute String loginId,
+            @RequestBody OrderRequestApproveDTO orderRequestApproveDTO
     ) {
-//        orderService.approveRequestedOrder(orderCode, loginId);
+        int memberCode = memberservice.getMemberByLoginId(loginId).getMemberCode();
+
+        boolean approved = orderService.approveOrderDraft(orderCode, memberCode, orderRequestApproveDTO);
         return ResponseEntity.ok(
                 new ResponseMessage<>(200, "successfully approved order request", null)
         );

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQSuperController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQSuperController.java
@@ -1,0 +1,31 @@
+package com.varc.brewnetapp.domain.order.command.application.controller;
+
+import com.varc.brewnetapp.common.ResponseMessage;
+import com.varc.brewnetapp.domain.order.command.application.service.OrderService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("api/v1/super/orders")
+public class HQSuperController {
+    private final OrderService orderService;
+
+    @Autowired
+    public HQSuperController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping("/approve/{orderCode}")
+    public ResponseEntity<ResponseMessage<Object>> approveOrderRequest(
+            @PathVariable String orderCode,
+            @RequestAttribute String loginId
+    ) {
+//        orderService.approveRequestedOrder(orderCode, loginId);
+        return ResponseEntity.ok(
+                new ResponseMessage<>(200, "successfully approved order request", null)
+        );
+    }
+}

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQSuperController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/controller/HQSuperController.java
@@ -3,6 +3,7 @@ package com.varc.brewnetapp.domain.order.command.application.controller;
 import com.varc.brewnetapp.common.ResponseMessage;
 import com.varc.brewnetapp.domain.member.query.service.MemberService;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestApproveDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestRejectDTO;
 import com.varc.brewnetapp.domain.order.command.application.service.OrderService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,21 @@ public class HQSuperController {
         boolean approved = orderService.approveOrderDraft(orderCode, memberCode, orderRequestApproveDTO);
         return ResponseEntity.ok(
                 new ResponseMessage<>(200, "successfully approved order request", null)
+        );
+    }
+
+    @PostMapping("/reject/{orderCode}")
+    @Operation(summary = "책임 관리자가 상신된 주문 요청에 대한 거절")
+    public ResponseEntity<ResponseMessage<Object>> rejectOrderRequest(
+            @PathVariable String orderCode,
+            @RequestAttribute String loginId,
+            @RequestBody OrderRequestRejectDTO orderRequestRejectDTO
+    ) {
+        int memberCode = memberservice.getMemberByLoginId(loginId).getMemberCode();
+
+        boolean rejected = orderService.rejectOrderDraft(orderCode, memberCode, orderRequestRejectDTO);
+        return  ResponseEntity.ok(
+                new ResponseMessage<>(200, "successfully rejected order request", null)
         );
     }
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/DrafterRejectOrderRequestDTO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/DrafterRejectOrderRequestDTO.java
@@ -1,0 +1,12 @@
+package com.varc.brewnetapp.domain.order.command.application.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class DrafterRejectOrderRequestDTO {
+    private String reason;
+}

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/OrderApproveRequestDTO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/OrderApproveRequestDTO.java
@@ -1,0 +1,13 @@
+package com.varc.brewnetapp.domain.order.command.application.dto;
+
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class OrderApproveRequestDTO {
+    private int superManagerMemberCode;
+}

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/OrderRequestApproveDTO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/OrderRequestApproveDTO.java
@@ -1,0 +1,12 @@
+package com.varc.brewnetapp.domain.order.command.application.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class OrderRequestApproveDTO {
+    private String comment;
+}

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/OrderRequestRejectDTO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/dto/OrderRequestRejectDTO.java
@@ -1,0 +1,12 @@
+package com.varc.brewnetapp.domain.order.command.application.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class OrderRequestRejectDTO {
+    private String comment;
+}

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.varc.brewnetapp.domain.order.command.application.service;
 
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -24,4 +25,9 @@ public interface OrderService {
     void rejectOrderByDrafter(int orderCode,
                               DrafterRejectOrderRequestDTO drafterRejectOrderRequestDTO,
                               String loginId);
+
+    // 주문 결재 상신
+    boolean requestApproveOrder(int orderCode,
+                                int memberCode,
+                                OrderApproveRequestDTO orderApproveRequestDTO);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
@@ -18,4 +18,6 @@ public interface OrderService {
     void addItemsPerOrder(int orderCode, List<OrderItemDTO> orderRequestRequestDTO);
 
     void cancelOrderRequest(Integer orderCode);
+
+    void rejectOrderByDrafter(int orderCode, String loginId);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
@@ -3,6 +3,7 @@ package com.varc.brewnetapp.domain.order.command.application.service;
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestApproveDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestRejectDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -34,4 +35,7 @@ public interface OrderService {
 
     // 상신된 주문에 대한 승인
     boolean approveOrderDraft(String orderCode, int memberCode, OrderRequestApproveDTO orderRequestApproveDTO);
+
+    // 상신된 주문에 대한 반려
+    boolean rejectOrderDraft(String orderCode, int memberCode, OrderRequestRejectDTO orderRequestRejectDTO);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
@@ -2,6 +2,7 @@ package com.varc.brewnetapp.domain.order.command.application.service;
 
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestApproveDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -30,4 +31,7 @@ public interface OrderService {
     boolean requestApproveOrder(int orderCode,
                                 int memberCode,
                                 OrderApproveRequestDTO orderApproveRequestDTO);
+
+    // 상신된 주문에 대한 승인
+    boolean approveOrderDraft(String orderCode, int memberCode, OrderRequestApproveDTO orderRequestApproveDTO);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.varc.brewnetapp.domain.order.command.application.service;
 
+import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -15,9 +16,12 @@ public interface OrderService {
     );
 
     // 주문별 품목 생성
-    void addItemsPerOrder(int orderCode, List<OrderItemDTO> orderRequestRequestDTO);
+    void addItemsPerOrder(int orderCode,
+                          List<OrderItemDTO> orderRequestRequestDTO);
 
     void cancelOrderRequest(Integer orderCode);
 
-    void rejectOrderByDrafter(int orderCode, String loginId);
+    void rejectOrderByDrafter(int orderCode,
+                              DrafterRejectOrderRequestDTO drafterRejectOrderRequestDTO,
+                              String loginId);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
@@ -6,6 +6,7 @@ import com.varc.brewnetapp.common.domain.order.OrderHistoryStatus;
 import com.varc.brewnetapp.common.domain.order.OrderApprovalStatus;
 import com.varc.brewnetapp.domain.member.query.service.MemberService;
 import com.varc.brewnetapp.domain.member.query.service.MemberServiceImpl;
+import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -123,22 +124,24 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Transactional
-    public void rejectOrderByDrafter(int orderCode, String loginId) {
-
-        // 기안자 찿기
-        int drafterMemberCode = memberService.getMemberByLoginId(loginId).getMemberCode();
+    public void rejectOrderByDrafter(int orderCode,
+                                     DrafterRejectOrderRequestDTO drafterRejectOrderRequestDTO,
+                                     String loginId) {
 
         // TODO: 가맹점의 주문 요청 반려
         //  - 주문 테이블에서 데이터 수정:
-        //  tbl_order.APPROVAL_STATUS - 'UNCONFIRMED' -> 'REJECTED'
-        //  tbl_order.DRAFTER_APPROVED - 'NONE' -> 'REJECT'
-        //  tbl_order.COMMENT - 사유 입력
-        //  tbl_order.MEMBER_CODE - 반려자(담당자) 코드 추가
+        //  tbl_order.APPROVAL_STATUS           - 'UNCONFIRMED' -> 'REJECTED'
+        //  tbl_order.DRAFTER_APPROVED          - 'NONE' -> 'REJECT'
+        //  tbl_order.COMMENT                   - 사유 입력
+        //  tbl_order.MEMBER_CODE               - 반려자(담당자) 코드 추가
         //  - 주문 상태 내역 테이블 수정:
-        //  tbl_order_status_history.status - 'REQUESTED' -> 'REJECTED'
+        //  tbl_order_status_history.status     - 'REQUESTED' -> 'REJECTED'
         //  tbl_order_status_history.CREATED_AT
         //  - 주문 별 상품 테이블 수정:
-        //  tbl_order_item.available - 'AVAILABLE' -> 'UNAVAILABLE'
+        //  tbl_order_item.available            - 'AVAILABLE' -> 'UNAVAILABLE'
+
+        String reason = drafterRejectOrderRequestDTO.getReason();
+        int drafterMemberCode = memberService.getMemberByLoginId(loginId).getMemberCode();
     }
 
     // 주문 상태 변화

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
@@ -7,6 +7,7 @@ import com.varc.brewnetapp.common.domain.order.OrderApprovalStatus;
 import com.varc.brewnetapp.domain.member.query.service.MemberService;
 import com.varc.brewnetapp.domain.member.query.service.MemberServiceImpl;
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -34,20 +35,18 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final OrderStatusHistoryRepository orderStatusHistoryRepository;
-    private final MemberServiceImpl queryMemberService;
 
     @Autowired
     public OrderServiceImpl(
             MemberService memberService,
             OrderRepository orderRepository,
             OrderStatusHistoryRepository orderStatusHistoryRepository,
-            OrderItemRepository orderItemRepository,
-            MemberServiceImpl queryMemberService) {
+            OrderItemRepository orderItemRepository
+    ) {
         this.memberService = memberService;
         this.orderRepository = orderRepository;
         this.orderStatusHistoryRepository = orderStatusHistoryRepository;
         this.orderItemRepository = orderItemRepository;
-        this.queryMemberService = queryMemberService;
     }
 
     // 가맹점의 주문요청
@@ -204,6 +203,24 @@ public class OrderServiceImpl implements OrderService {
         );
         orderItemRepository.saveAll(newOrderItemList);
 
+    }
+
+    @Transactional
+    @Override
+    public boolean requestApproveOrder(
+            int orderCode,
+            int memberCode,
+            OrderApproveRequestDTO orderApproveRequestDTO
+    ) {
+        // TODO: 일반 관리자의 상신
+        //  - tbl_order 수정
+        //    - approval_status UNCONFIRMED인지 확인
+        //    - member_code(기안자) 할당
+        //  - tbl_order_status_history
+        //    - status REQUESTED -> PENDING
+        //  - tbl_order_approver 추가
+        //    - approved -> UNCONFIRMED
+        return true;
     }
 
     // 주문 상태 변화

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
@@ -138,6 +138,26 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Transactional
+    @Override
+    public boolean requestApproveOrder(
+            int orderCode,
+            int memberCode,
+            OrderApproveRequestDTO orderApproveRequestDTO
+    ) {
+        Order order = orderRepository.findById(orderCode).orElseThrow(() -> new OrderNotFound("Order not found"));
+
+        // TODO: 일반 관리자의 상신
+        //  - tbl_order 수정
+        //    - approval_status UNCONFIRMED인지 확인
+        //    - member_code(기안자) 할당
+        //  - tbl_order_status_history
+        //    - status REQUESTED -> PENDING
+        //  - tbl_order_approver 추가
+        //    - approved -> UNCONFIRMED
+        return true;
+    }
+
+    @Transactional
     public void rejectOrderByDrafter(int orderCode,
                                      DrafterRejectOrderRequestDTO drafterRejectOrderRequestDTO,
                                      String loginId) {
@@ -187,40 +207,22 @@ public class OrderServiceImpl implements OrderService {
         List<OrderItem> newOrderItemList = new ArrayList<>();
         orderItemList.forEach(
                 orderItem ->
-                    newOrderItemList.add(
-                            OrderItem.builder()
-                                    .orderItemCode(
-                                            OrderItemCode.builder()
-                                                    .orderCode(orderItem.getOrderItemCode().getOrderCode())
-                                                    .itemCode(orderItem.getOrderItemCode().getItemCode())
-                                                    .build()
-                                    )
-                                    .quantity(orderItem.getQuantity())
-                                    .available(Available.UNAVAILABLE)
-                                    .partSumPrice(orderItem.getPartSumPrice())
-                                    .build()
-                    )
+                        newOrderItemList.add(
+                                OrderItem.builder()
+                                        .orderItemCode(
+                                                OrderItemCode.builder()
+                                                        .orderCode(orderItem.getOrderItemCode().getOrderCode())
+                                                        .itemCode(orderItem.getOrderItemCode().getItemCode())
+                                                        .build()
+                                        )
+                                        .quantity(orderItem.getQuantity())
+                                        .available(Available.UNAVAILABLE)
+                                        .partSumPrice(orderItem.getPartSumPrice())
+                                        .build()
+                        )
         );
         orderItemRepository.saveAll(newOrderItemList);
 
-    }
-
-    @Transactional
-    @Override
-    public boolean requestApproveOrder(
-            int orderCode,
-            int memberCode,
-            OrderApproveRequestDTO orderApproveRequestDTO
-    ) {
-        // TODO: 일반 관리자의 상신
-        //  - tbl_order 수정
-        //    - approval_status UNCONFIRMED인지 확인
-        //    - member_code(기안자) 할당
-        //  - tbl_order_status_history
-        //    - status REQUESTED -> PENDING
-        //  - tbl_order_approver 추가
-        //    - approved -> UNCONFIRMED
-        return true;
     }
 
     // 주문 상태 변화

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
@@ -9,6 +9,7 @@ import com.varc.brewnetapp.domain.member.query.service.MemberServiceImpl;
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestApproveDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestRejectDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -178,7 +179,25 @@ public class OrderServiceImpl implements OrderService {
         //    - approval_status -> APPROVED
         //  - tbl_order_status_history 추가
         //    - STATUS -> APPROVED
-        return false;
+
+        // TODO: 재고 변화
+        return true;
+    }
+
+    @Transactional
+    @Override
+    public boolean rejectOrderDraft(String orderCode, int memberCode, OrderRequestRejectDTO orderRequestRejectDTO) {
+
+        // TODO: 책임 관리자의 상신에 대한 반려 처리
+        //  - tbl_order_approver 수정
+        //    - approved UNCONFIRMED -> APPROVED
+        //    - CREATED_AT -> 수정
+        //    - COMMENT -> 수정
+        //  - tbl_order 수정
+        //    - approval_status -> APPROVED
+        //  - tbl_order_status_history 추가
+        //    - STATUS -> APPROVED
+        return true;
     }
 
     @Transactional

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/application/service/OrderServiceImpl.java
@@ -8,6 +8,7 @@ import com.varc.brewnetapp.domain.member.query.service.MemberService;
 import com.varc.brewnetapp.domain.member.query.service.MemberServiceImpl;
 import com.varc.brewnetapp.domain.order.command.application.dto.DrafterRejectOrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.OrderApproveRequestDTO;
+import com.varc.brewnetapp.domain.order.command.application.dto.OrderRequestApproveDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderItemDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestDTO;
 import com.varc.brewnetapp.domain.order.command.application.dto.orderrequest.OrderRequestResponseDTO;
@@ -137,6 +138,7 @@ public class OrderServiceImpl implements OrderService {
         log.debug("order history updated: {}", orderStatusHistoryRepository);
     }
 
+    // 가맹점 주문 요청에 대한 일반 관리자의 상신
     @Transactional
     @Override
     public boolean requestApproveOrder(
@@ -148,13 +150,35 @@ public class OrderServiceImpl implements OrderService {
 
         // TODO: 일반 관리자의 상신
         //  - tbl_order 수정
-        //    - approval_status UNCONFIRMED인지 확인
+        //    - approval_status UNCONFIRMED인지 확인 (validate)
+        //    - member_code(기안자) 할당된 바 있는지 확인 (validate)
         //    - member_code(기안자) 할당
-        //  - tbl_order_status_history
+        //    - drafter_approved NONE -> APPROVE
+        //  - tbl_order_status_history 추가
         //    - status REQUESTED -> PENDING
         //  - tbl_order_approver 추가
         //    - approved -> UNCONFIRMED
+        //  - tbl_order_item 수정
+        //    - 해당 order_item의 available -> UNAVAILABLE
+//        orderStatusHistoryRepository.save()
         return true;
+    }
+
+    // 일반 관리자의 주문 승인 상신 요청에 대한 책임 관리자의 승인
+    @Transactional
+    @Override
+    public boolean approveOrderDraft(String orderCode, int memberCode, OrderRequestApproveDTO orderRequestApproveDTO) {
+
+        // TODO: 책임 관리자의 상신에 대한 승인 처리
+        //  - tbl_order_approver 수정
+        //    - approved UNCONFIRMED -> APPROVED
+        //    - CREATED_AT -> 수정
+        //    - COMMENT -> 수정
+        //  - tbl_order 수정
+        //    - approval_status -> APPROVED
+        //  - tbl_order_status_history 추가
+        //    - STATUS -> APPROVED
+        return false;
     }
 
     @Transactional

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/domain/aggregate/entity/compositionkey/OrderItemCode.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/domain/aggregate/entity/compositionkey/OrderItemCode.java
@@ -4,6 +4,7 @@ package com.varc.brewnetapp.domain.order.command.domain.aggregate.entity.composi
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
@@ -11,6 +12,7 @@ import java.util.Objects;
 
 @Builder
 @Embeddable
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class OrderItemCode implements Serializable {

--- a/src/main/java/com/varc/brewnetapp/domain/order/command/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/command/domain/repository/OrderItemRepository.java
@@ -1,7 +1,11 @@
 package com.varc.brewnetapp.domain.order.command.domain.repository;
 
 import com.varc.brewnetapp.domain.order.command.domain.aggregate.entity.OrderItem;
+import com.varc.brewnetapp.domain.order.command.domain.aggregate.entity.compositionkey.OrderItemCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+import java.util.List;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, OrderItemCode> {
+    List<OrderItem> findByOrderItemCode_OrderCode(int orderCode);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/query/controller/FranchiseOrderQueryController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/query/controller/FranchiseOrderQueryController.java
@@ -1,6 +1,7 @@
 package com.varc.brewnetapp.domain.order.query.controller;
 
 import com.varc.brewnetapp.common.ResponseMessage;
+import com.varc.brewnetapp.domain.member.query.service.MemberServiceImpl;
 import com.varc.brewnetapp.domain.order.query.dto.FranchiseOrderDTO;
 import com.varc.brewnetapp.domain.order.query.dto.HQOrderDTO;
 import com.varc.brewnetapp.domain.order.query.dto.OrderDetailForFranchiseDTO;
@@ -21,24 +22,29 @@ import org.springframework.web.bind.annotation.*;
 public class FranchiseOrderQueryController {
 
     private final OrderQueryService orderQueryService;
+    private final MemberServiceImpl queryMemberService;
 
     @Autowired
     public FranchiseOrderQueryController(
-            OrderQueryService orderQueryService
-    ) {
+            OrderQueryService orderQueryService,
+            MemberServiceImpl queryMemberService) {
         this.orderQueryService = orderQueryService;
+        this.queryMemberService = queryMemberService;
     }
 
-    @GetMapping("/list/{franchiseCode}")
+    @GetMapping("/list")
     @Operation(summary = "가맹점의 주문리스트 조회")
     public ResponseEntity<ResponseMessage<Page<FranchiseOrderDTO>>> getOrderList(
             @PageableDefault(size = 10, page = 0) Pageable pageable,
-            @PathVariable("franchiseCode") Integer franchiseCode,
+            @RequestAttribute("loginId") String loginId,
             @RequestParam(name = "filter", required = false) String filter,
             @RequestParam(name = "sort", required = false) String sort,
             @RequestParam(name = "startDate", required = false) String startDate,
             @RequestParam(name = "endDate", required = false) String endDate
     ) {
+        int franchiseCode = queryMemberService.getFranchiseInfoByLoginId(loginId)
+                .getFranchiseCode();
+
         Page<FranchiseOrderDTO> orderDTOList = orderQueryService.getOrderListForFranchise(
                 pageable,
                 filter,

--- a/src/main/java/com/varc/brewnetapp/domain/order/query/mapper/OrderValidateMapper.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/query/mapper/OrderValidateMapper.java
@@ -9,4 +9,8 @@ public interface OrderValidateMapper {
             @Param("franchiseCode") int franchiseCode,
             @Param("orderCode") int orderCode
     );
+
+    boolean checkIsOrderItemMoreThenOne(
+            @Param("orderCode") int orderCode
+    );
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/query/service/OrderValidateService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/query/service/OrderValidateService.java
@@ -2,4 +2,5 @@ package com.varc.brewnetapp.domain.order.query.service;
 
 public interface OrderValidateService {
     boolean isOrderFromFranchise(int franchiseCode, int orderCode);
+    boolean isOrderItemsMoreThenOne(int orderCode);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/order/query/service/OrderValidateServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/order/query/service/OrderValidateServiceImpl.java
@@ -3,6 +3,7 @@ package com.varc.brewnetapp.domain.order.query.service;
 import com.varc.brewnetapp.domain.order.query.mapper.OrderValidateMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class OrderValidateServiceImpl implements OrderValidateService {
@@ -14,8 +15,15 @@ public class OrderValidateServiceImpl implements OrderValidateService {
         this.orderValidateMapper = orderValidateMapper;
     }
 
+    @Transactional
     @Override
     public boolean isOrderFromFranchise(int franchiseCode, int orderCode) {
         return orderValidateMapper.checkIsOrderFrom(franchiseCode, orderCode);
+    }
+
+    @Transactional
+    @Override
+    public boolean isOrderItemsMoreThenOne(int orderCode) {
+        return orderValidateMapper.checkIsOrderItemMoreThenOne(orderCode);
     }
 }

--- a/src/main/java/com/varc/brewnetapp/security/config/SecurityConfiguration.java
+++ b/src/main/java/com/varc/brewnetapp/security/config/SecurityConfiguration.java
@@ -61,6 +61,9 @@ public class SecurityConfiguration {
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/hq/**")).hasAnyRole("MASTER", "GENERAL_ADMIN", "RESPONSIBLE_ADMIN")
 
                         // 본사책임자
+                        .requestMatchers(new AntPathRequestMatcher("/api/v1/super/**")).hasRole("RESPONSIBLE_ADMIN")
+
+                        // 본사책임자
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/responsible/**")).hasAnyRole("MASTER", "RESPONSIBLE_ADMIN")
 
                         // 마스터

--- a/src/main/resources/com/varc/brewnetapp/domain/order/query/mapper/OrderValidateMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/order/query/mapper/OrderValidateMapper.xml
@@ -10,5 +10,20 @@
          WHERE o.order_code = #{orderCode}
                AND
                o.franchise_code = #{franchiseCode}
+               AND
+               o.ACTIVE = 1
+    </select>
+
+    <select id="checkIsOrderItemMoreThenOne" resultType="boolean">
+        SELECT
+               CASE
+                    WHEN COUNT(*) > 0
+                         THEN true
+                         ELSE false
+               END
+          FROM tbl_order_item oi
+         WHERE oi.order_code = #{orderCode}
+               AND
+               oi.ACTIVE = 1
     </select>
 </mapper>


### PR DESCRIPTION
### 요약
- 가맹점의 주문요청 방식 변경

### 관련 이슈
- 토큰과 가맹점 정보가 localStorage로 관리되는가

### 완료 사항
- 가맹점의 주문요청 방식 변경
    - 기존: 프론트에서 franchiseCode를 준다고 가정
    - 변경: 프론트에서 토큰을 전달받아 토큰에서 공개 claim에 담긴 loginId를 파싱하여 가져와, 별도로 franchiseInfo 요청

### 필요 테스트
- 완료한 기능에 대한 테스트 케이스

### 스크린샷 (선택사항)
- 사진을 업로드해주세요

### 체크리스트
- [ ] 닌자코드로 작성하지 않았나요?
- [ ] 작성 코드에 대한 셀프체크를 하셨나요?
- [ ] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [ ] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [ ] 테스트코드가 모두 잘 작동하나요?
