### PR TITLE
fix: 결재라인 선택 시 결재자 목록 조회 api 위치 이동

### DIFF
--- a/src/main/java/com/varc/brewnetapp/domain/document/query/controller/DocumentController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/document/query/controller/DocumentController.java
@@ -4,14 +4,13 @@ import com.varc.brewnetapp.common.ResponseMessage;
 import com.varc.brewnetapp.domain.document.query.dto.ApproverDTO;
 import com.varc.brewnetapp.domain.document.query.service.ApprovalService;
 import com.varc.brewnetapp.domain.document.query.dto.ApprovalDTO;
+import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController(value = "queryDocumentController")
 @RequestMapping("api/v1/hq/document")
@@ -35,5 +34,16 @@ public class DocumentController {
     public ResponseEntity<ResponseMessage<List<ApproverDTO>>> findApprover() {
 
         return ResponseEntity.ok(new ResponseMessage<>(200, "결재 목록 조회 성공", approvalService.findApproverlList()));
+    }
+
+    @GetMapping("/approvers")
+    @Operation(summary = "결재라인 선택 시 결재자인 회원 목록 조회 API")
+    public ResponseEntity<ResponseMessage<List<ApproverMemberDTO>>> selectApproverList(
+                                                        @RequestParam KindOfApproval approvalLine) {
+
+        List<ApproverMemberDTO> approverList = approvalService.selectApproverList(approvalLine);
+
+        return ResponseEntity.ok(new ResponseMessage<>(
+                                    200, "해당 결재라인의 결재자 목록 조회 성공", approverList));
     }
 }

--- a/src/main/java/com/varc/brewnetapp/domain/document/query/dto/ApproverMemberDTO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/document/query/dto/ApproverMemberDTO.java
@@ -1,6 +1,5 @@
-package com.varc.brewnetapp.domain.purchase.query.dto;
+package com.varc.brewnetapp.domain.document.query.dto;
 
-import com.varc.brewnetapp.domain.purchase.common.IsApproved;
 import com.varc.brewnetapp.domain.purchase.common.PositionNameEx;
 import lombok.*;
 
@@ -9,7 +8,7 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-public class PurchaseApproverMemberDTO {
+public class ApproverMemberDTO {
 
     private int approverCode;               // 결재자 회원코드
     private String approverName;            // 결재자명

--- a/src/main/java/com/varc/brewnetapp/domain/document/query/mapper/DocumentMapper.java
+++ b/src/main/java/com/varc/brewnetapp/domain/document/query/mapper/DocumentMapper.java
@@ -3,6 +3,9 @@ package com.varc.brewnetapp.domain.document.query.mapper;
 import com.varc.brewnetapp.domain.document.query.dto.ApprovalDTO;
 import com.varc.brewnetapp.domain.document.query.dto.ApproverDTO;
 import java.util.List;
+
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
+import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
@@ -10,4 +13,6 @@ public interface DocumentMapper {
     List<ApprovalDTO> selectApprovalList();
 
     List<ApproverDTO> selectApproverList();
+
+    List<ApproverMemberDTO> selectApproversByKind(KindOfApproval approvalLine);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/document/query/service/ApprovalService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/document/query/service/ApprovalService.java
@@ -1,8 +1,11 @@
 package com.varc.brewnetapp.domain.document.query.service;
 
 import com.varc.brewnetapp.domain.document.query.dto.ApproverDTO;
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
 import com.varc.brewnetapp.domain.document.query.mapper.DocumentMapper;
 import com.varc.brewnetapp.domain.document.query.dto.ApprovalDTO;
+import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
+import com.varc.brewnetapp.exception.ApprovalNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,5 +32,12 @@ public class ApprovalService {
         List<ApproverDTO> approverList = documentMapper.selectApproverList();
 
         return approverList;
+    }
+
+    public List<ApproverMemberDTO> selectApproverList(KindOfApproval approvalLine) {
+        List<ApproverMemberDTO> approvers = documentMapper.selectApproversByKind(approvalLine);
+        if (approvers == null) throw new ApprovalNotFoundException("존재하지 않는 결재라인입니다.");
+
+        return approvers;
     }
 }

--- a/src/main/java/com/varc/brewnetapp/domain/purchase/query/controller/PurchaseController.java
+++ b/src/main/java/com/varc/brewnetapp/domain/purchase/query/controller/PurchaseController.java
@@ -1,6 +1,7 @@
 package com.varc.brewnetapp.domain.purchase.query.controller;
 
 import com.varc.brewnetapp.common.ResponseMessage;
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
 import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
 import com.varc.brewnetapp.domain.purchase.common.PageResponse;
 import com.varc.brewnetapp.domain.purchase.query.dto.*;
@@ -110,17 +111,5 @@ public class PurchaseController {
                                                     startDate, endDate, pageNumber, pageSize);
 
         return ResponseEntity.ok(new ResponseMessage<>(200, "입고 미확인 품목 목록 조회 성공", pageResponse));
-    }
-
-    @GetMapping("/approvers")
-    @Operation(summary = "결재라인 선택 시 결재자인 회원 목록 조회 API")
-    public ResponseEntity<ResponseMessage<List<PurchaseApproverMemberDTO>>> selectApproverList(
-                                                                        @RequestAttribute("loginId") String loginId,
-                                                                        @RequestParam KindOfApproval approvalLine) {
-
-        List<PurchaseApproverMemberDTO> approverList = purchaseService.selectApproverList(loginId, approvalLine);
-
-        return ResponseEntity.ok(new ResponseMessage<>(
-                                200, "해당 결재라인의 결재자 목록 조회 성공", approverList));
     }
 }

--- a/src/main/java/com/varc/brewnetapp/domain/purchase/query/mapper/PurchaseMapper.java
+++ b/src/main/java/com/varc/brewnetapp/domain/purchase/query/mapper/PurchaseMapper.java
@@ -1,5 +1,6 @@
 package com.varc.brewnetapp.domain.purchase.query.mapper;
 
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
 import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
 import com.varc.brewnetapp.domain.purchase.common.SearchPurchaseCriteria;
 import com.varc.brewnetapp.domain.purchase.common.SearchPurchaseItemCriteria;
@@ -26,6 +27,4 @@ public interface PurchaseMapper {
     List<ApprovedPurchaseItemDTO> selectApprovedPurchaseItemUncheck(SearchPurchaseItemCriteria criteria);
 
     int getApprovedPurchaseItemUncheckCount(SearchPurchaseItemCriteria criteria);
-
-    List<PurchaseApproverMemberDTO> selectApproversByKind(KindOfApproval approvalLine);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/purchase/query/service/PurchaseService.java
+++ b/src/main/java/com/varc/brewnetapp/domain/purchase/query/service/PurchaseService.java
@@ -1,5 +1,6 @@
 package com.varc.brewnetapp.domain.purchase.query.service;
 
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
 import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
 import com.varc.brewnetapp.domain.purchase.common.PageResponse;
 import com.varc.brewnetapp.domain.purchase.query.dto.*;
@@ -41,6 +42,4 @@ public interface PurchaseService {
                                                                                   String endDate,
                                                                                   int pageNumber,
                                                                                   int pageSize);
-
-    List<PurchaseApproverMemberDTO> selectApproverList(String loginId, KindOfApproval approvalLine);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/purchase/query/service/PurchaseServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/purchase/query/service/PurchaseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.varc.brewnetapp.domain.purchase.query.service;
 
+import com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO;
 import com.varc.brewnetapp.domain.purchase.common.KindOfApproval;
 import com.varc.brewnetapp.domain.purchase.common.PageResponse;
 import com.varc.brewnetapp.domain.purchase.common.SearchPurchaseCriteria;
@@ -169,14 +170,5 @@ public class PurchaseServiceImpl implements PurchaseService {
                                                                 purchaseItems, pageNumber, pageSize, totalCount);
 
         return response;
-    }
-
-    @Override
-    public List<PurchaseApproverMemberDTO> selectApproverList(String loginId, KindOfApproval approvalLine) {
-
-        List<PurchaseApproverMemberDTO> approvers = purchaseMapper.selectApproversByKind(approvalLine);
-        if (approvers == null) throw new ApprovalNotFoundException("존재하지 않는 결재라인입니다.");
-
-        return approvers;
     }
 }

--- a/src/main/resources/com/varc/brewnetapp/domain/document/query/mapper/DocumentMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/document/query/mapper/DocumentMapper.xml
@@ -14,6 +14,11 @@
     <result property="positionName" column="NAME"/>
   </resultMap>
 
+  <resultMap id="approverListResultMap" type="com.varc.brewnetapp.domain.document.query.dto.ApproverMemberDTO">
+    <id property="approverCode" column="MEMBER_CODE"/>
+    <result property="approverName" column="MEMBER_NAME"/>
+    <result property="positionName" column="POSITION_NAME"/>
+  </resultMap>
 
   <select id="selectApprovalList" resultMap="approvalResultMap">
     SELECT
@@ -30,5 +35,22 @@
            NAME
       FROM tbl_position
      WHERE NAME != 'STAFF'
+  </select>
+
+  <!-- 결재 구분으로 해당 결재라인에 속한 결재자들 조회 -->
+  <select id="selectApproversByKind"
+          parameterType="com.varc.brewnetapp.domain.purchase.common.KindOfApproval"
+          resultMap="approverListResultMap">
+    SELECT
+           M.MEMBER_CODE,
+           M.NAME AS MEMBER_NAME,
+           P.NAME AS POSITION_NAME
+      FROM TBL_MEMBER M
+      JOIN TBL_POSITION P ON M.POSITION_CODE = P.POSITION_CODE
+      JOIN TBL_APPROVAL A ON P.POSITION_CODE = A.POSITION_CODE
+    <where>
+        A.KIND = #{approvalLine}
+    </where>
+     ORDER BY M.NAME ASC
   </select>
 </mapper>

--- a/src/main/resources/com/varc/brewnetapp/domain/purchase/query/mapper/PurchaseMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/purchase/query/mapper/PurchaseMapper.xml
@@ -72,13 +72,6 @@
         <result property="storageName" column="STORAGE_NAME"/>
     </resultMap>
 
-    <resultMap id="approverListResultMap"
-               type="com.varc.brewnetapp.domain.purchase.query.dto.PurchaseApproverMemberDTO">
-        <id property="approverCode" column="MEMBER_CODE"/>
-        <result property="approverName" column="MEMBER_NAME"/>
-        <result property="positionName" column="POSITION_NAME"/>
-    </resultMap>
-
     <!-- 발주 내역(구매품의서) 목록 조회 및 검색 -->
     <select id="searchLettersOfPurchase"
             parameterType="com.varc.brewnetapp.domain.purchase.common.SearchPurchaseCriteria"
@@ -389,22 +382,5 @@
             </choose>
         </where>
         ORDER BY P.CREATED_AT DESC
-    </select>
-
-    <!-- 결재 구분으로 해당 결재라인에 속한 결재자들 조회 -->
-    <select id="selectApproversByKind"
-            parameterType="com.varc.brewnetapp.domain.purchase.common.KindOfApproval"
-            resultMap="approverListResultMap">
-        SELECT
-               M.MEMBER_CODE,
-               M.NAME AS MEMBER_NAME,
-               P.NAME AS POSITION_NAME
-          FROM TBL_MEMBER M
-          JOIN TBL_POSITION P ON M.POSITION_CODE = P.POSITION_CODE
-          JOIN TBL_APPROVAL A ON P.POSITION_CODE = A.POSITION_CODE
-        <where>
-            A.KIND = #{approvalLine}
-        </where>
-         ORDER BY M.NAME ASC
     </select>
 </mapper>


### PR DESCRIPTION
### 요약
- 결재라인 선택 시 결재자 목록 조회 api 위치 이동

### 관련 이슈
- 

### 완료 사항
- 결재라인 선택 시 결재자 목록 조회 api를 purchase controller에서 document controller로 이동했습니다.

### 필요 테스트
- 완료한 기능에 대한 테스트 케이스

### 스크린샷 (선택사항)
- 사진을 업로드해주세요

### 체크리스트
- [ ] 닌자코드로 작성하지 않았나요?
- [ ] 작성 코드에 대한 셀프체크를 하셨나요?
- [ ] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [ ] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [ ] 테스트코드가 모두 잘 작동하나요?
