### PR TITLE
fix: 발주내역의 결재라인 조회 시 결재자의 첨언도 반환하도록 수정

### DIFF
--- a/src/main/java/com/varc/brewnetapp/domain/purchase/query/dto/PurchaseApproverDTO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/purchase/query/dto/PurchaseApproverDTO.java
@@ -10,10 +10,11 @@ import lombok.*;
 @ToString
 public class PurchaseApproverDTO {
 
-    private int letterOfPurchaseCode;
+    private int letterOfPurchaseCode;       // 구매품의서 코드
     private int approverCode;               // 결재자 회원코드
-    private IsApproved approved;
-    private String approvedAt;
-    private String approverName;
-    private String positionName;
+    private IsApproved approved;            // 결재자의 결재 상태
+    private String approvedAt;              // 결재일시
+    private String comment;                 // 결재자의 첨언
+    private String approverName;            // 결재자명
+    private String positionName;            // 결재자의 직급명
 }

--- a/src/main/resources/com/varc/brewnetapp/domain/purchase/query/mapper/PurchaseMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/purchase/query/mapper/PurchaseMapper.xml
@@ -55,6 +55,7 @@
             <id property="approverCode" column="APPROVER_CODE"/>
             <result property="approved" column="APPROVED"/>
             <result property="approvedAt" column="APPROVED_AT"/>
+            <result property="comment" column="COMMENT"/>
             <result property="approverName" column="APPROVER_NAME"/>
             <result property="positionName" column="POSITION_NAME"/>
         </collection>
@@ -199,6 +200,7 @@
                A.MEMBER_CODE AS APPROVER_CODE,
                A.APPROVED,
                A.APPROVED_AT,
+               A.COMMENT,
                B.NAME AS APPROVER_NAME,
                O.NAME AS POSITION_NAME
           FROM TBL_LETTER_OF_PURCHASE P


### PR DESCRIPTION
### 요약
- 발주내역의 결재라인 조회 시 결재자의 첨언도 반환하도록 수정

### 관련 이슈
- 

### 완료 사항
- 발주내역의 결재라인 조회 시 결재자의 첨언도 반환하도록 수정했습니다.

### 필요 테스트
- 완료한 기능에 대한 테스트 케이스

### 스크린샷 (선택사항)
- 사진을 업로드해주세요

### 체크리스트
- [ ] 닌자코드로 작성하지 않았나요?
- [ ] 작성 코드에 대한 셀프체크를 하셨나요?
- [ ] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [ ] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [ ] 테스트코드가 모두 잘 작동하나요?
