### PR TITLE
fix: 본사 교환/반품요청 결재자 조회 시 결재자코드 포함하도록 수정

### DIFF
--- a/src/main/java/com/varc/brewnetapp/domain/exchange/query/aggregate/vo/ExchangeApproverVO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/exchange/query/aggregate/vo/ExchangeApproverVO.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class ExchangeApproverVO {
+    private String approverCode;
     private String approverName;        // 결재자(기안자)
     private Position position;          // 직급
     private Approval approval;          // 결재 처리 상태

--- a/src/main/java/com/varc/brewnetapp/domain/exchange/query/mapper/ExchangeMapper.java
+++ b/src/main/java/com/varc/brewnetapp/domain/exchange/query/mapper/ExchangeMapper.java
@@ -56,4 +56,6 @@ public interface ExchangeMapper {
     List<Integer> selectAvailableExchangeBy(String loginId);
 
     List<FranExchangeItemVO> selectAvailableExchangeItemBy(int orderCode);
+
+    int selectSearchExchangeListCnt(String searchFilter, String searchWord, String startDate, String endDate);
 }

--- a/src/main/java/com/varc/brewnetapp/domain/exchange/query/service/ExchangeServiceImpl.java
+++ b/src/main/java/com/varc/brewnetapp/domain/exchange/query/service/ExchangeServiceImpl.java
@@ -81,7 +81,7 @@ public class ExchangeServiceImpl implements ExchangeService {
 
 
         // 전체 데이터 개수 조회
-        int count = exchangeMapper.selectExchangeListCnt();
+        int count = exchangeMapper.selectSearchExchangeListCnt(searchFilter, searchWord, startDate, endDate);
 
         // PageImpl 객체로 감싸서 반환
         return new PageImpl<>(exchangeList, page, count);

--- a/src/main/java/com/varc/brewnetapp/domain/returning/query/aggregate/vo/ReturningApproverVO.java
+++ b/src/main/java/com/varc/brewnetapp/domain/returning/query/aggregate/vo/ReturningApproverVO.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class ReturningApproverVO {
+    private int approverCode;
     private String approverName;        // 결재자(기안자)
     private Position position;          // 직급
     private Approval approval;          // 결재 처리 상태

--- a/src/main/resources/com/varc/brewnetapp/domain/exchange/query/mapper/ExchangeMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/exchange/query/mapper/ExchangeMapper.xml
@@ -130,6 +130,7 @@
 
     <!-- 본사 교환 결재진행상황 조회 ResultMap -->
     <resultMap id="exchangeApproverResultMap" type="com.varc.brewnetapp.domain.exchange.query.aggregate.vo.ExchangeApproverVO">
+        <result property="approverCode" column="approver_code"/>
         <result property="approverName" column="approver_name"/>
         <result property="position" column="position"/>
         <result property="approval" column="approval"/>
@@ -801,7 +802,8 @@
     <!-- (본사)교환상세보기 페이지 - '결재진행상황' 버튼 클릭 시 사용 -->
     <select id="selectExchangeApproverBy" resultMap="exchangeApproverResultMap">
         SELECT
-              B.name AS approver_name
+              B.code AS approver_code
+            , B.name AS approver_name
             , C.name AS position
             , A.approved AS approval
             , A.created_at

--- a/src/main/resources/com/varc/brewnetapp/domain/exchange/query/mapper/ExchangeMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/exchange/query/mapper/ExchangeMapper.xml
@@ -309,6 +309,52 @@
         LIMIT #{ offset }, #{ pageSize };
     </select>
 
+    <!-- 교환내역 검색 페이지네이션용 cnt 쿼리 -->
+    <select id="selectSearchExchangeListCnt" resultType="int">
+        SELECT COUNT(*)
+        FROM (
+        SELECT
+              A.exchange_code
+            , C.franchise_name
+            , GROUP_CONCAT(E.name SEPARATOR ', ') AS item_name
+            , A.reason
+            , F.name AS member_name
+            , A.created_at
+            , G.status
+            , A.approval_status
+         FROM tbl_exchange A
+              JOIN tbl_order B ON A.order_code = B.order_code
+              JOIN tbl_franchise C ON B.franchise_code = C.franchise_code
+              JOIN tbl_exchange_item D ON A.exchange_code = D.exchange_code
+              JOIN tbl_item E ON D.item_code = E.item_code
+              LEFT JOIN tbl_member F ON A.member_code = F.member_code
+              JOIN tbl_exchange_status_history G ON A.exchange_code = G.exchange_code
+              JOIN (
+                    SELECT exchange_code, MAX(created_at) AS max_created_at
+                    FROM tbl_exchange_status_history
+                    GROUP BY exchange_code
+                    ) latest_status ON G.exchange_code = latest_status.exchange_code
+          AND G.created_at = latest_status.max_created_at
+        <where>
+            <choose>
+                <when test="searchFilter == 'exchangeCode'">
+                    AND CAST(A.exchange_code AS CHAR) LIKE CONCAT('%', #{ searchWord }, '%')
+                </when>
+                <when test="searchFilter == 'franchiseName'">
+                    AND C.franchise_name LIKE CONCAT('%', #{ searchWord }, '%')
+                </when>
+                <when test="searchFilter == 'managerName'">
+                    AND F.name LIKE CONCAT('%', #{ searchWord }, '%')
+                </when>
+            </choose>
+            <if test="startDate != null and endDate != null">
+                AND A.created_at BETWEEN #{ startDate } AND CONCAT(#{ endDate }, ' 23:59:59')
+            </if>
+        </where>
+        GROUP BY A.exchange_code, C.franchise_name, A.reason, F.name, A.created_at, G.status, A.approval_status
+        ) AS grouped_result;
+    </select>
+
     <!-- 교환내역 검색 쿼리 -->
     <select id="selectSearchExchangeList" resultMap="exchangeListResultMap">
         SELECT
@@ -352,45 +398,6 @@
         GROUP BY A.exchange_code, C.franchise_name, A.reason, F.name, A.created_at, G.status, A.approval_status
         ORDER BY A.created_at DESC
         LIMIT #{ offset }, #{ pageSize };
-    </select>
-
-    <select id="selectSearchExchangeListCnt" resultType="int">
-        SELECT
-              COUNT(*)
-        FROM (
-              SELECT
-                    A.exchange_code
-                FROM tbl_exchange A
-                     JOIN tbl_order B ON A.order_code = B.order_code
-                     JOIN tbl_franchise C ON B.franchise_code = C.franchise_code
-                     JOIN tbl_exchange_item D ON A.exchange_code = D.exchange_code
-                     JOIN tbl_item E ON D.item_code = E.item_code
-                     LEFT JOIN tbl_member F ON A.member_code = F.member_code
-                     JOIN tbl_exchange_status_history G ON A.exchange_code = G.exchange_code
-                     JOIN (
-                           SELECT exchange_code, MAX(created_at) AS max_created_at
-                           FROM tbl_exchange_status_history
-                           GROUP BY exchange_code
-                           ) latest_status ON G.exchange_code = latest_status.exchange_code
-        AND G.created_at = latest_status.max_created_at
-        <where>
-            <choose>
-                <when test="searchFilter == 'exchangeCode'">
-                    AND CAST(A.exchange_code AS CHAR) LIKE CONCAT('%', #{ searchWord }, '%')
-                </when>
-                <when test="searchFilter == 'franchiseName'">
-                    AND C.franchise_name LIKE CONCAT('%', #{ searchWord }, '%')
-                </when>
-                <when test="searchFilter == 'managerName'">
-                    AND F.name LIKE CONCAT('%', #{ searchWord }, '%')
-                </when>
-            </choose>
-            <if test="startDate != null and endDate != null">
-                AND A.created_at BETWEEN #{ startDate } AND CONCAT(#{ endDate }, ' 23:59:59')
-            </if>
-        </where>
-        GROUP BY A.exchange_code, C.franchise_name, A.reason, F.name, A.created_at, G.status, A.approval_status
-        ) AS grouped_results;
     </select>
 
     <!-- 교환내역 상세조회 쿼리 -->

--- a/src/main/resources/com/varc/brewnetapp/domain/returning/query/mapper/ReturningMapper.xml
+++ b/src/main/resources/com/varc/brewnetapp/domain/returning/query/mapper/ReturningMapper.xml
@@ -49,6 +49,7 @@
 
     <!-- 본사 반품 결재진행상황 조회 ResultMap-->
     <resultMap id="returningApproverResultMap" type="com.varc.brewnetapp.domain.returning.query.aggregate.vo.ReturningApproverVO">
+        <result property="approverCode" column="approver_code"/>
         <result property="approverName" column="approver_name"/>
         <result property="position" column="position"/>
         <result property="approval" column="approval"/>
@@ -488,7 +489,8 @@
     <!-- (본사)반품상세보기 페이지 - '결재진행상황' 버튼 클릭 시 사용 -->
     <select id="selectReturningApproverBy" resultMap="returningApproverResultMap">
         SELECT
-        B.name AS approver_name
+          B.member_code AS approver_code
+        , B.name AS approver_name
         , C.name AS position
         , A.approved AS approval
         , A.created_at


### PR DESCRIPTION
### 요약
- 본사 교환/반품요청 결재자 조회 시 결재자코드 포함하도록 수정

### 관련 이슈

### 완료 사항
- 본사 교환/반품요청 결재자 조회 시 결재자코드 포함하도록 수정

### 필요 테스트
- X

### 스크린샷 (선택사항)
- 사진을 업로드해주세요

### 체크리스트
- [ ] 닌자코드로 작성하지 않았나요?
- [ ] 작성 코드에 대한 셀프체크를 하셨나요?
- [ ] 이해가 어려운 부분에 대한 주석이나 설명이 잘 작성됐나요?
- [ ] 공유된 이슈 사항 및 요구사항을 만족하였나요?
- [ ] 테스트코드가 모두 잘 작동하나요?
